### PR TITLE
intermediate revision - count the processes accurately

### DIFF
--- a/ReSampler.bat
+++ b/ReSampler.bat
@@ -47,7 +47,7 @@ for /R "%SourcePath%" %%I in (*.flac) do (
     set /A PROCESS_COUNTER+=1
     if !PROCESS_COUNTER! geq !MAX_PROCESSES! (
         rem Wait for any of the launched processes to finish before launching more
-        CALL :WAIT_FOR_PROCESS
+        CALL :COUNT_FOR_PROCESS
     )
 )
 
@@ -61,4 +61,23 @@ for /f "tokens=3" %%a in ('TASKLIST /FI "WINDOWTITLE eq C:\ReSampler\ReSampler.e
     )
 )
 set "PROCESS_COUNTER=0"
+exit /B
+goto :EOF
+
+REM use trick from https://devblogs.microsoft.com/oldnewthing/20110825-00/?p=9803
+:COUNT_FOR_PROCESS
+echo Wait untill at least one processes finish
+rem Wait untill at least one processes finish
+C:\Windows\System32\timeout.exe /T !TIMEOUT! /nobreak 
+set IMAGENAME=ReSampler.exe
+set /A RUNNING_PPOCESS_COUNT=0
+for /f "tokens=1" %%_ in ('tasklist.exe /FI "IMAGENAME eq !IMAGENAME!" /NH ^| C:\Windows\System32\find.exe "!IMAGENAME!" ^|C:\Windows\System32\find.exe/c /v "" ') do (
+    set /A RUNNING_PPOCESS_COUNT=%%_
+    echo !RUNNING_PPOCESS_COUNT! !IMAGENAME! is running
+    if !RUNNING_PPOCESS_COUNT! equ !MAX_PROCESSES! (
+       goto :COUNT_FOR_PROCESS
+    )
+)
+set /A "PROCESS_COUNTER=!MAX_PROCESSES! - !RUNNING_PPOCESS_COUNT!"
+echo set PROCESS_COUNTER to !PROCESS_COUNTER!
 exit /B

--- a/ReSampler.bat
+++ b/ReSampler.bat
@@ -78,6 +78,6 @@ for /f "tokens=1" %%_ in ('tasklist.exe /FI "IMAGENAME eq !IMAGENAME!" /NH ^| C:
        goto :COUNT_FOR_PROCESS
     )
 )
-set /A "PROCESS_COUNTER=!MAX_PROCESSES! - !RUNNING_PPOCESS_COUNT!"
+set /A "PROCESS_COUNTER=!RUNNING_PPOCESS_COUNT!"
 echo set PROCESS_COUNTER to !PROCESS_COUNTER!
 exit /B


### PR DESCRIPTION
Rather than waiting for all running Resampler.exe to finish and zero the `PROCESS_COUNTER`, count running, and when some finish, decrement the PROCESS_COUNTER by the # possible to start.